### PR TITLE
Update DB setup to remove pandas and parse CSV manually

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -1,102 +1,144 @@
 from sqlalchemy.orm import declarative_base, relationship
-from sqlalchemy import Column, String, Integer, Float, DateTime, ForeignKey
+from sqlalchemy import Column, String, Integer, Float, DateTime, ForeignKey, SmallInteger
 
 Base = declarative_base()
 
 class OlistCustomersDataset(Base):
-    __tablename__ = 'olist_customers_dataset'
-    customer_id = Column(String, primary_key=True)
-    customer_unique_id = Column(String)
-    customer_zip_code_prefix = Column(Integer)
-    customer_city = Column(String)
-    customer_state = Column(String)
+    __tablename__ = "olist_customers_dataset"
+
+    customer_id = Column(String(50), primary_key=True, nullable=False)
+    customer_unique_id = Column(String(50), nullable=False)
+    customer_zip_code_prefix = Column(Integer, nullable=False)
+    customer_city = Column(String(50), nullable=False)
+    customer_state = Column(String(50), nullable=False)
+
     # Relationships
-    orders = relationship('OlistOrdersDataset', back_populates='customer')
+    orders = relationship("OlistOrdersDataset", back_populates="customer")
+
 
 class OlistOrdersDataset(Base):
-    __tablename__ = 'olist_orders_dataset'
-    order_id = Column(String, primary_key=True)
-    customer_id = Column(String, ForeignKey('olist_customers_dataset.customer_id'))
-    order_status = Column(String)
-    order_purchase_timestamp = Column(DateTime)
-    order_approved_at = Column(DateTime)
-    order_delivered_carrier_date = Column(DateTime)
-    order_delivered_customer_date = Column(DateTime)
-    order_estimated_delivery_date = Column(DateTime)
+    __tablename__ = "olist_orders_dataset"
+
+    order_id = Column(String(50), primary_key=True, nullable=False)
+    customer_id = Column(
+        String(50), ForeignKey("olist_customers_dataset.customer_id"), nullable=False
+    )
+    order_status = Column(String(50), nullable=False)
+    order_purchase_timestamp = Column(DateTime, nullable=False)
+    order_approved_at = Column(DateTime, nullable=True)
+    order_delivered_carrier_date = Column(DateTime, nullable=True)
+    order_delivered_customer_date = Column(DateTime, nullable=True)
+    order_estimated_delivery_date = Column(DateTime, nullable=False)
+
     # Relationships
-    customer = relationship('OlistCustomersDataset', back_populates='orders')
-    order_items = relationship('OlistOrderItemsDataset', back_populates='order')
-    order_payments = relationship('OlistOrderPaymentsDataset', back_populates='order')
-    order_reviews = relationship('OlistOrderReviewsDataset', back_populates='order')
+    customer = relationship("OlistCustomersDataset", back_populates="orders")
+    order_items = relationship("OlistOrderItemsDataset", back_populates="order")
+    order_payments = relationship("OlistOrderPaymentsDataset", back_populates="order")
+    order_reviews = relationship("OlistOrderReviewsDataset", back_populates="order")
+
 
 class OlistOrderItemsDataset(Base):
-    __tablename__ = 'olist_order_items_dataset'
-    order_id = Column(String, ForeignKey('olist_orders_dataset.order_id'), primary_key=True)
-    order_item_id = Column(Integer, primary_key=True)
-    product_id = Column(String, ForeignKey('olist_products_dataset.product_id'))
-    seller_id = Column(String, ForeignKey('olist_sellers_dataset.seller_id'))
-    shipping_limit_date = Column(DateTime)
-    price = Column(Float)
-    freight_value = Column(Float)
+    __tablename__ = "olist_order_items_dataset"
+
+    order_id = Column(
+        String(50),
+        ForeignKey("olist_orders_dataset.order_id"),
+        primary_key=True,
+        nullable=False,
+    )
+    order_item_id = Column(SmallInteger, primary_key=True, nullable=False)
+    product_id = Column(
+        String(50), ForeignKey("olist_products_dataset.product_id"), nullable=False
+    )
+    seller_id = Column(
+        String(50), ForeignKey("olist_sellers_dataset.seller_id"), nullable=False
+    )
+    shipping_limit_date = Column(DateTime, nullable=False)
+    price = Column(Float, nullable=False)
+    freight_value = Column(Float, nullable=False)
+
     # Relationships
-    order = relationship('OlistOrdersDataset', back_populates='order_items')
-    product = relationship('OlistProductsDataset', back_populates='order_items')
-    seller = relationship('OlistSellersDataset', back_populates='order_items')
+    order = relationship("OlistOrdersDataset", back_populates="order_items")
+    product = relationship("OlistProductsDataset", back_populates="order_items")
+    seller = relationship("OlistSellersDataset", back_populates="order_items")
+
 
 class OlistOrderPaymentsDataset(Base):
-    __tablename__ = 'olist_order_payments_dataset'
-    order_id = Column(String, ForeignKey('olist_orders_dataset.order_id'), primary_key=True)
-    payment_sequential = Column(Integer, primary_key=True)
-    payment_type = Column(String)
-    payment_installments = Column(Integer)
-    payment_value = Column(Float)
+    __tablename__ = "olist_order_payments_dataset"
+
+    order_id = Column(
+        String(50),
+        ForeignKey("olist_orders_dataset.order_id"),
+        primary_key=True,
+        nullable=False,
+    )
+    payment_sequential = Column(SmallInteger, primary_key=True, nullable=False)
+    payment_type = Column(String(50), nullable=False)
+    payment_installments = Column(SmallInteger, nullable=False)
+    payment_value = Column(Float, nullable=False)
+
     # Relationships
-    order = relationship('OlistOrdersDataset', back_populates='order_payments')
+    order = relationship("OlistOrdersDataset", back_populates="order_payments")
+
 
 class OlistOrderReviewsDataset(Base):
-    __tablename__ = 'olist_order_reviews_dataset'
-    review_id = Column(String, primary_key=True)
-    order_id = Column(String, ForeignKey('olist_orders_dataset.order_id'))
-    review_score = Column(Integer)
-    review_comment_title = Column(String)
-    review_comment_message = Column(String)
-    review_creation_date = Column(DateTime)
-    review_answer_timestamp = Column(DateTime)
+    __tablename__ = "olist_order_reviews_dataset"
+
+    review_id = Column(String(50), primary_key=True, nullable=False)
+    order_id = Column(
+        String(50), ForeignKey("olist_orders_dataset.order_id"), nullable=False
+    )
+    review_score = Column(SmallInteger, nullable=False)
+    review_comment_title = Column(String(50), nullable=True)
+    review_comment_message = Column(String(250), nullable=True)
+    review_creation_date = Column(DateTime, nullable=False)
+    review_answer_timestamp = Column(DateTime, nullable=False)
+
     # Relationships
-    order = relationship('OlistOrdersDataset', back_populates='order_reviews')
+    order = relationship("OlistOrdersDataset", back_populates="order_reviews")
+
 
 class OlistProductsDataset(Base):
-    __tablename__ = 'olist_products_dataset'
-    product_id = Column(String, primary_key=True)
-    product_category_name = Column(String)
-    product_name_lenght = Column(Integer)
-    product_description_lenght = Column(Integer)
-    product_photos_qty = Column(Integer)
-    product_weight_g = Column(Integer)
-    product_length_cm = Column(Integer)
-    product_height_cm = Column(Integer)
-    product_width_cm = Column(Integer)
+    __tablename__ = "olist_products_dataset"
+
+    product_id = Column(String(50), primary_key=True, nullable=False)
+    product_category_name = Column(String(50), nullable=True)
+    product_name_lenght = Column(Integer, nullable=True)
+    product_description_lenght = Column(Integer, nullable=True)
+    product_photos_qty = Column(SmallInteger, nullable=True)
+    product_weight_g = Column(Integer, nullable=True)
+    product_length_cm = Column(Integer, nullable=True)
+    product_height_cm = Column(Integer, nullable=True)
+    product_width_cm = Column(Integer, nullable=True)
+
     # Relationships
-    order_items = relationship('OlistOrderItemsDataset', back_populates='product')
+    order_items = relationship("OlistOrderItemsDataset", back_populates="product")
+
 
 class OlistSellersDataset(Base):
-    __tablename__ = 'olist_sellers_dataset'
-    seller_id = Column(String, primary_key=True)
-    seller_zip_code_prefix = Column(Integer)
-    seller_city = Column(String)
-    seller_state = Column(String)
+    __tablename__ = "olist_sellers_dataset"
+
+    seller_id = Column(String(50), primary_key=True, nullable=False)
+    seller_zip_code_prefix = Column(Integer, nullable=False)
+    seller_city = Column(String(50), nullable=False)
+    seller_state = Column(String(50), nullable=False)
+
     # Relationships
-    order_items = relationship('OlistOrderItemsDataset', back_populates='seller')
+    order_items = relationship("OlistOrderItemsDataset", back_populates="seller")
+
 
 class OlistGeolocationDataset(Base):
-    __tablename__ = 'olist_geolocation_dataset'
-    geolocation_zip_code_prefix = Column(Integer, primary_key=True)
-    geolocation_lat = Column(Float)
-    geolocation_lng = Column(Float)
-    geolocation_city = Column(String)
-    geolocation_state = Column(String)
+    __tablename__ = "olist_geolocation_dataset"
+
+    geolocation_zip_code_prefix = Column(Integer, primary_key=True, nullable=False)
+    geolocation_lat = Column(Float, nullable=False)
+    geolocation_lng = Column(Float, nullable=False)
+    geolocation_city = Column(String(50), nullable=False)
+    geolocation_state = Column(String(50), nullable=False)
+
 
 class ProductCategoryNameTranslation(Base):
-    __tablename__ = 'product_category_name_translation'
-    product_category_name = Column(String, primary_key=True)
-    product_category_name_english = Column(String)
+    __tablename__ = "product_category_name_translation"
+
+    product_category_name = Column(String(50), primary_key=True, nullable=False)
+    product_category_name_english = Column(String(50), nullable=False)


### PR DESCRIPTION
## Summary
- drop pandas dependency in `db_setup`
- manually parse CSVs with `csv` module and handle datetimes
- keep ORM models aligned with schema

## Testing
- `python -m py_compile db/db_setup.py db/models.py`
- `pytest -q`
- `python -m db.db_setup` *(fails: sqlalchemy missing)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687942d6b33c8322a2ab040f75600f70