### PR TITLE
Modular setup via scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ OPENAI_API_KEY=sk-xxxxxx
 ```bash
 python main.py
 ```
+The first execution automatically builds `olist.db` and the FAQ vector store by
+running the setup modules.
 
 Example conversation:
 

--- a/db/db_setup.py
+++ b/db/db_setup.py
@@ -159,25 +159,23 @@ def populate_database(engine, data_folder=DATA_FOLDER, table_map=CSV_TABLE_MAP):
     print("[POPULATE] All CSV imports attempted.")
 
 def get_session(engine):
-    """
-    Returns a new SQLAlchemy ORM session for database operations.
-    """
+    """Return a new SQLAlchemy ORM session for the given engine."""
     Session = sessionmaker(bind=engine)
     return Session()
 
-# --- Example usage (for standalone testing) ---
-if __name__ == "__main__":
-    print("[MAIN] Running db_setup.py directly (standalone test mode)")
+
+def setup_database():
+    """Create tables and populate them from CSV files."""
     engine = create_db_and_tables()
-    print("[MAIN] Now populating database from CSV files ...")
     populate_database(engine)
-    session = get_session(engine)
-    print("[MAIN] Example: Fetch 5 orders from 'olist_orders_dataset':")
-    try:
-        orders = session.query(OlistOrdersDataset).limit(5).all()
-        for order in orders:
-            print("Order:", order.order_id, order.customer_id, order.order_status)
-    except Exception as e:
-        print(f"[MAIN][ERROR] Could not query orders: {e}")
-    finally:
-        session.close()
+    return engine
+
+
+def main():
+    print("[MAIN] Creating database and importing CSV files ...")
+    setup_database()
+    print("[MAIN] Database setup complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 from agent.workflow import ask_agent
-from db.db_setup import create_db_and_tables, populate_database
-from vectorstore.faq_vectorstore import FAQVectorStore
-from config import DATABASE_FILE, VECTOR_DB_DIR, DATABASE_URL, DATA_FOLDER, CSV_TABLE_MAP
+from config import DATABASE_FILE, VECTOR_DB_DIR, DATABASE_URL
 from sqlalchemy import create_engine, text
+import subprocess
 import os
 
 def initial_setup():
@@ -11,14 +10,10 @@ def initial_setup():
     Only runs on first launch or when files are missing.
     """
     print("[SETUP] Performing initial setup ...")
-    # 1. Database
-    print("[SETUP] Checking and creating DB + tables ...")
-    engine = create_db_and_tables(database_url=DATABASE_URL)
-    print("[SETUP] Populating database ...")
-    populate_database(engine, data_folder=DATA_FOLDER, table_map=CSV_TABLE_MAP)
-    # 2. Vectorstore
-    print("[SETUP] Ensuring FAQ vector store is ready ...")
-    FAQVectorStore()  # Will populate if empty
+    print("[SETUP] Creating and populating database ...")
+    subprocess.run(["python", "-m", "db.db_setup"], check=True)
+    print("[SETUP] Building FAQ vector store ...")
+    subprocess.run(["python", "-m", "vectorstore.faq_vectorstore"], check=True)
     print("[SETUP] Initial setup complete.\n")
 
 def vectorstore_exists() -> bool:

--- a/vectorstore/faq_vectorstore.py
+++ b/vectorstore/faq_vectorstore.py
@@ -63,8 +63,26 @@ class FAQVectorStore:
         self.vector_db.add_texts([text], ids=[new_id])
         print(f"Added FAQ #{new_id}")
 
-# For quick usage:
-faq_vectorstore = FAQVectorStore()
+faq_vectorstore = None
+
+def get_faq_vectorstore() -> FAQVectorStore:
+    """Return a singleton instance of FAQVectorStore, creating it if needed."""
+    global faq_vectorstore
+    if faq_vectorstore is None:
+        faq_vectorstore = FAQVectorStore()
+    return faq_vectorstore
 
 def semantic_faq_search(query, k=2):
-    return faq_vectorstore.semantic_search(query, k=k)
+    """Convenience wrapper for performing a FAQ semantic search."""
+    store = get_faq_vectorstore()
+    return store.semantic_search(query, k=k)
+
+
+def main():
+    """Command line entry-point for building the FAQ vector store."""
+    get_faq_vectorstore()
+    print("FAQ vector store is ready.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make main.py run setup modules via subprocess
- lazily create engine in workflow
- add CLI entry point for FAQ vector store
- simplify db_setup main block
- document automatic setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879d6b0299c8322af4977e1e1b6f04f